### PR TITLE
Update copyright year in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Elena Loonstra
+Copyright (c) 2024 Elena Loonstra
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Updated the copyright year from 2023 to 2024 to reflect the current year. This ensures the LICENSE file stays accurate and up to date.